### PR TITLE
Fix dev stackoverflow and entities realations

### DIFF
--- a/src/main/java/com/construction_worker_forum_back/controller/CommentController.java
+++ b/src/main/java/com/construction_worker_forum_back/controller/CommentController.java
@@ -32,6 +32,12 @@ public class CommentController {
         return commentService.getAllComments();
     }
 
+    @SecurityRequirement(name = "Bearer Authentication")
+    @GetMapping("/all_by_username/{username}")
+    public List<CommentDto> getAllCommentsByUsername(@PathVariable String username) {
+        return commentService.getCommentsByUsername(username);
+    }
+
     @GetMapping("/{id}")
     CommentDto getComment(@PathVariable Long id) {
         return commentService.findById(id).orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));

--- a/src/main/java/com/construction_worker_forum_back/controller/PostController.java
+++ b/src/main/java/com/construction_worker_forum_back/controller/PostController.java
@@ -28,6 +28,12 @@ public class PostController {
         return postService.getAllPosts();
     }
 
+    @SecurityRequirement(name = "Bearer Authentication")
+    @GetMapping("/all_by_username/{username}")
+    public List<PostDto> getAllPostsByUsername(@PathVariable String username) {
+        return postService.getPostsByUsername(username);
+    }
+
     @GetMapping("/{id}")
     public PostDto getPostById(@PathVariable("id") Long id) {
         return postService.findById(id)

--- a/src/main/java/com/construction_worker_forum_back/controller/TopicController.java
+++ b/src/main/java/com/construction_worker_forum_back/controller/TopicController.java
@@ -42,8 +42,6 @@ public class TopicController {
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     TopicDto createTopic(@Valid @RequestBody TopicRequestDto topicRequestDto) {
-        log.info(String.valueOf(topicRequestDto));
-
         return topicService.createTopic(topicRequestDto);
     }
 

--- a/src/main/java/com/construction_worker_forum_back/controller/UserController.java
+++ b/src/main/java/com/construction_worker_forum_back/controller/UserController.java
@@ -1,7 +1,5 @@
 package com.construction_worker_forum_back.controller;
 
-import com.construction_worker_forum_back.model.dto.CommentDto;
-import com.construction_worker_forum_back.model.dto.PostDto;
 import com.construction_worker_forum_back.model.dto.UserDto;
 import com.construction_worker_forum_back.model.dto.UserRequestDto;
 import com.construction_worker_forum_back.service.UserService;
@@ -47,22 +45,6 @@ public class UserController {
     UserDto getUserByUsername(@RequestParam(value = "username") String username) {
         return userService
                 .findByUsername(username)
-                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
-    }
-
-    @SecurityRequirement(name = "Bearer Authentication")
-    @GetMapping("/{username}/posts")
-    List<PostDto> getUserPosts(@PathVariable String username) {
-        return userService
-                .findByUsername(username).map(UserDto::getUserPosts)
-                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
-    }
-
-    @SecurityRequirement(name = "Bearer Authentication")
-    @GetMapping("/{username}/comments")
-    List<CommentDto> getUserComments(@PathVariable String username) {
-        return userService
-                .findByUsername(username).map(UserDto::getUserComments)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
     }
 

--- a/src/main/java/com/construction_worker_forum_back/model/dto/CommentDto.java
+++ b/src/main/java/com/construction_worker_forum_back/model/dto/CommentDto.java
@@ -1,5 +1,7 @@
 package com.construction_worker_forum_back.model.dto;
 
+import com.construction_worker_forum_back.model.dto.simple.PostSimpleDto;
+import com.construction_worker_forum_back.model.dto.simple.UserSimpleDto;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -16,6 +18,6 @@ public class CommentDto {
     private String content;
     private Date createdAt;
     private Date updatedAt;
-    private UserDto user;
-    private PostDto post;
+    private UserSimpleDto user;
+    private PostSimpleDto post;
 }

--- a/src/main/java/com/construction_worker_forum_back/model/dto/PostDto.java
+++ b/src/main/java/com/construction_worker_forum_back/model/dto/PostDto.java
@@ -1,6 +1,12 @@
 package com.construction_worker_forum_back.model.dto;
 
-import lombok.*;
+import com.construction_worker_forum_back.model.dto.simple.CommentSimpleDto;
+import com.construction_worker_forum_back.model.dto.simple.TopicSimpleDto;
+import com.construction_worker_forum_back.model.dto.simple.UserSimpleDto;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.util.Date;
 import java.util.List;
@@ -15,7 +21,7 @@ public class PostDto {
     private String content;
     private Date createdAt;
     private Date updatedAt;
-    private UserDto user;
-    private List<CommentDto> comments;
-    private TopicDto topic;
+    private UserSimpleDto user;
+    private List<CommentSimpleDto> comments;
+    private TopicSimpleDto topic;
 }

--- a/src/main/java/com/construction_worker_forum_back/model/dto/TopicRequestDto.java
+++ b/src/main/java/com/construction_worker_forum_back/model/dto/TopicRequestDto.java
@@ -1,6 +1,9 @@
 package com.construction_worker_forum_back.model.dto;
 
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import javax.validation.constraints.Size;
 
@@ -12,6 +15,4 @@ public class TopicRequestDto {
 
     @Size(min = 3, max = 20)
     private String name;
-
-    private Long postId;
 }

--- a/src/main/java/com/construction_worker_forum_back/model/dto/simple/CommentSimpleDto.java
+++ b/src/main/java/com/construction_worker_forum_back/model/dto/simple/CommentSimpleDto.java
@@ -1,22 +1,19 @@
-package com.construction_worker_forum_back.model.dto;
+package com.construction_worker_forum_back.model.dto.simple;
 
-import com.construction_worker_forum_back.model.dto.simple.PostSimpleDto;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.util.Date;
-import java.util.List;
 
 @Getter
 @Setter
 @AllArgsConstructor
 @NoArgsConstructor
-public class TopicDto {
+public class CommentSimpleDto {
     private Long id;
-    private String name;
+    private String content;
     private Date createdAt;
     private Date updatedAt;
-    private List<PostSimpleDto> posts;
 }

--- a/src/main/java/com/construction_worker_forum_back/model/dto/simple/PostSimpleDto.java
+++ b/src/main/java/com/construction_worker_forum_back/model/dto/simple/PostSimpleDto.java
@@ -1,22 +1,20 @@
-package com.construction_worker_forum_back.model.dto;
+package com.construction_worker_forum_back.model.dto.simple;
 
-import com.construction_worker_forum_back.model.dto.simple.PostSimpleDto;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.util.Date;
-import java.util.List;
 
 @Getter
 @Setter
 @AllArgsConstructor
 @NoArgsConstructor
-public class TopicDto {
+public class PostSimpleDto {
     private Long id;
-    private String name;
+    private String title;
+    private String content;
     private Date createdAt;
     private Date updatedAt;
-    private List<PostSimpleDto> posts;
 }

--- a/src/main/java/com/construction_worker_forum_back/model/dto/simple/TopicSimpleDto.java
+++ b/src/main/java/com/construction_worker_forum_back/model/dto/simple/TopicSimpleDto.java
@@ -1,22 +1,19 @@
-package com.construction_worker_forum_back.model.dto;
+package com.construction_worker_forum_back.model.dto.simple;
 
-import com.construction_worker_forum_back.model.dto.simple.PostSimpleDto;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.util.Date;
-import java.util.List;
 
 @Getter
 @Setter
 @AllArgsConstructor
 @NoArgsConstructor
-public class TopicDto {
+public class TopicSimpleDto {
     private Long id;
     private String name;
     private Date createdAt;
     private Date updatedAt;
-    private List<PostSimpleDto> posts;
 }

--- a/src/main/java/com/construction_worker_forum_back/model/dto/simple/UserSimpleDto.java
+++ b/src/main/java/com/construction_worker_forum_back/model/dto/simple/UserSimpleDto.java
@@ -1,7 +1,5 @@
-package com.construction_worker_forum_back.model.dto;
+package com.construction_worker_forum_back.model.dto.simple;
 
-import com.construction_worker_forum_back.model.dto.simple.CommentSimpleDto;
-import com.construction_worker_forum_back.model.dto.simple.PostSimpleDto;
 import com.construction_worker_forum_back.model.security.AccountStatus;
 import com.construction_worker_forum_back.model.security.Role;
 import lombok.AllArgsConstructor;
@@ -10,13 +8,12 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.util.Date;
-import java.util.List;
 
 @Getter
 @Setter
 @AllArgsConstructor
 @NoArgsConstructor
-public class UserDto {
+public class UserSimpleDto {
     private Long id;
     private String username;
     private String email;
@@ -27,6 +24,4 @@ public class UserDto {
     private Date updatedAt;
     private AccountStatus accountStatus;
     private Role userRoles;
-    private List<CommentSimpleDto> userComments;
-    private List<PostSimpleDto> userPosts;
 }

--- a/src/main/java/com/construction_worker_forum_back/model/entity/Comment.java
+++ b/src/main/java/com/construction_worker_forum_back/model/entity/Comment.java
@@ -35,11 +35,11 @@ public class Comment {
     @Column(name = "updated_at")
     private Date updatedAt;
 
-    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.MERGE)
     @JoinColumn(name = "user_id", referencedColumnName = "id")
     private User user;
 
-    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.MERGE)
     @JoinColumn(name = "post_id", referencedColumnName = "id")
     private Post post;
 

--- a/src/main/java/com/construction_worker_forum_back/model/entity/Post.java
+++ b/src/main/java/com/construction_worker_forum_back/model/entity/Post.java
@@ -38,11 +38,11 @@ public class Post {
     @Column(name = "updated_at")
     private Date updatedAt;
 
-    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.MERGE)
     @JoinColumn(name = "user_id", referencedColumnName = "id")
     private User user;
 
-    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.MERGE)
     @JoinColumn(name = "topic_id", referencedColumnName = "id")
     private Topic topic;
 

--- a/src/main/java/com/construction_worker_forum_back/model/entity/Topic.java
+++ b/src/main/java/com/construction_worker_forum_back/model/entity/Topic.java
@@ -6,6 +6,7 @@ import org.springframework.data.annotation.LastModifiedDate;
 
 import javax.persistence.*;
 import javax.validation.constraints.Size;
+import java.time.Instant;
 import java.util.Date;
 import java.util.List;
 
@@ -35,4 +36,9 @@ public class Topic {
 
     @OneToMany(mappedBy = "topic", cascade = CascadeType.ALL)
     private List<Post> posts;
+
+    @PrePersist
+    private void beforeSaving() {
+        createdAt = Date.from(Instant.now());
+    }
 }

--- a/src/main/java/com/construction_worker_forum_back/repository/CommentRepository.java
+++ b/src/main/java/com/construction_worker_forum_back/repository/CommentRepository.java
@@ -2,10 +2,13 @@ package com.construction_worker_forum_back.repository;
 
 import com.construction_worker_forum_back.model.entity.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.lang.NonNull;
 
 import java.util.List;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+    List<Comment> findByUser_UsernameIgnoreCase(@NonNull String username);
 
     int deleteCommentById(Long id);
 

--- a/src/main/java/com/construction_worker_forum_back/repository/PostRepository.java
+++ b/src/main/java/com/construction_worker_forum_back/repository/PostRepository.java
@@ -3,10 +3,13 @@ package com.construction_worker_forum_back.repository;
 import com.construction_worker_forum_back.model.entity.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.lang.NonNull;
 
 import java.util.List;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
+
+    List<Post> findByUser_UsernameIgnoreCase(@NonNull String username);
 
     int deletePostById(Long postId);
 

--- a/src/main/java/com/construction_worker_forum_back/service/CommentService.java
+++ b/src/main/java/com/construction_worker_forum_back/service/CommentService.java
@@ -37,6 +37,14 @@ public class CommentService {
                 .toList();
     }
 
+    public List<CommentDto> getCommentsByUsername(String username) {
+        return commentRepository
+                .findByUser_UsernameIgnoreCase(username)
+                .stream()
+                .map(comment -> modelMapper.map(comment, CommentDto.class))
+                .toList();
+    }
+
     public Optional<CommentDto> findById(Long id) {
         return commentRepository.findById(id)
                 .map(comment -> modelMapper.map(comment, CommentDto.class));

--- a/src/main/java/com/construction_worker_forum_back/service/PostService.java
+++ b/src/main/java/com/construction_worker_forum_back/service/PostService.java
@@ -37,6 +37,14 @@ public class PostService {
                 .toList();
     }
 
+    public List<PostDto> getPostsByUsername(String username) {
+        return postRepository
+                .findByUser_UsernameIgnoreCase(username)
+                .stream()
+                .map(post -> modelMapper.map(post, PostDto.class))
+                .toList();
+    }
+
     public Optional<PostDto> findById(Long id) {
         return postRepository.findById(id)
                 .map(post -> modelMapper.map(post, PostDto.class));

--- a/src/main/java/com/construction_worker_forum_back/service/TopicService.java
+++ b/src/main/java/com/construction_worker_forum_back/service/TopicService.java
@@ -50,7 +50,6 @@ public class TopicService {
     @Transactional
     public TopicDto createTopic(TopicRequestDto topicRequestDto) {
         Topic topicToSave = modelMapper.map(topicRequestDto, Topic.class);
-        topicToSave.setCreatedAt(Date.from(Instant.now()));
 
         return modelMapper.map(topicRepository.save(topicToSave), TopicDto.class);
     }

--- a/src/main/java/com/construction_worker_forum_back/service/UserService.java
+++ b/src/main/java/com/construction_worker_forum_back/service/UserService.java
@@ -27,7 +27,6 @@ public class UserService implements UserDetailsService {
     private final UserRepository userRepository;
     private final ModelMapper modelMapper;
     private final PasswordEncoder passwordEncoder;
-
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
         Optional<User> user = userRepository.findByUsernameIgnoreCase(username);

--- a/src/main/java/com/construction_worker_forum_back/service/UserService.java
+++ b/src/main/java/com/construction_worker_forum_back/service/UserService.java
@@ -27,6 +27,7 @@ public class UserService implements UserDetailsService {
     private final UserRepository userRepository;
     private final ModelMapper modelMapper;
     private final PasswordEncoder passwordEncoder;
+
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
         Optional<User> user = userRepository.findByUsernameIgnoreCase(username);


### PR DESCRIPTION
Panowie, pogrzebałem trochę w devie i podrzucam listę, co zmieniłem/"naprawiłem":

- Nie powinno występować już zagnieżdżanie DTOsów, ustawiłem wszędzie, żeby zwracało uproszczone DTO. Np. getPostById zwraca teraz UserSimpleDto bez listy postów i komentarzy, List<CommentSimpleDto> każdy z CommentSimpleDto ma uproszczoną wersję UserSimpleDto i PostSimpleDto, więc nie dochodzi do pętli, itd. itp.


- Przeniosłem endpointy wyszukiwania postów i komentarzy Usera do odpowiadających im controllerów. Ze względu na zmiany w kodzie, tak jest znacznie bardziej intuicyjnie.


- Data Topica przy jego tworzeniu jest ustawiana teraz w klasie encji za pomocą @PrePersist, tak jak w reszcie encji.


- W encjach przy @ManyToOne poustawiałem CascadeType.MERGE zamiast ALL, żeby Nam wszystko w relacjach banglało.

- Aby stworzyć Topic, nie potrzeba teraz postId

Potestowałem w postmanie zmiany. Nigdzie nie wystąpił mi StackOverFlow + relacje działają w każdym kierunku + nie powinnien teraz występować problem N+1.